### PR TITLE
Bump condiut version and semver version

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [project]
 
 name = "civet"
-version = "0.8.3"
+version = "0.9.0"
 authors = ["wycats"]
 license = "MIT"
 description = "civetweb-based server implementation for conduit"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,8 +8,8 @@ description = "civetweb-based server implementation for conduit"
 repository = "https://github.com/wycats/rust-civet"
 
 [dependencies]
-conduit = "0.7"
-semver = "0.2.0"
+conduit = "0.8"
+semver = "0.5.0"
 libc = "0.2"
 
 [dependencies.civet-sys]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -8,7 +8,7 @@ use std::io::prelude::*;
 use std::io::{self, BufWriter};
 use std::net::{SocketAddr, Ipv4Addr, SocketAddrV4};
 
-use conduit::{Request, Handler, Extensions, TypeMap, Method, Scheme, Host};
+use conduit::{Handler, Extensions, TypeMap, Method, Scheme, Host};
 
 use raw::{RequestInfo,Header};
 use raw::{get_header,get_headers,get_request_info};


### PR DESCRIPTION
Relies on https://github.com/conduit-rust/conduit/pull/10

This also bumps the version of civet, let me know if that's not what you want.

There's also one tiny fix to remove a warning.