### PR TITLE
Fix windows build

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,3 +1,5 @@
+dist: trusty
+sudo: false
 language: rust
 script:
   - cargo build --verbose

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [project]
 
 name = "civet"
-version = "0.9.1"
+version = "0.10.0"
 authors = ["wycats"]
 license = "MIT"
 description = "civetweb-based server implementation for conduit"
@@ -14,7 +14,7 @@ libc = "0.2"
 
 [dependencies.civet-sys]
 path = "civet-sys"
-version = "0.1.0"
+version = "0.2.0"
 
 [dev-dependencies]
 route-recognizer = "0.1.0"

--- a/civet-sys/Cargo.toml
+++ b/civet-sys/Cargo.toml
@@ -12,3 +12,6 @@ description = "Native bindings to the libcivetweb library"
 [lib]
 name = "civet_sys"
 path = "lib.rs"
+
+[build-dependencies]
+cmake = "0.1"

--- a/civet-sys/Cargo.toml
+++ b/civet-sys/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 
 name = "civet-sys"
-version = "0.1.4"
+version = "0.2.0"
 authors = ["Alex Crichton <alex@alexcrichton.com>"]
 links = "civet"
 build = "build.rs"

--- a/civet-sys/build.rs
+++ b/civet-sys/build.rs
@@ -1,26 +1,12 @@
-use std::env;
-use std::fs;
-use std::process::Command;
-use std::path::Path;
+extern crate cmake;
+
+use cmake::Config;
 
 fn main() {
-    let dst = env::var("OUT_DIR").unwrap();
-
-    assert!(Command::new("make")
-                    .current_dir("civetweb")
-                    .arg("lib")
-                    .arg(&format!("BUILD_DIR={}", dst))
-                    .env("COPT", "-fPIC")
-                    .status().unwrap().success());
-
-    {
-        let src = Path::new("civetweb/libcivetweb.a");
-        let dst = Path::new(&dst).join("libcivetweb.a");
-        if fs::rename(&src, &dst).is_err() {
-            fs::copy(&src, &dst).unwrap();
-            fs::remove_file(&src).unwrap();
-        }
-    }
-
-    println!("cargo:rustc-flags=-L {} -l static=civetweb", dst);
+    let mut dst = Config::new("civetweb")
+                         .define("CMAKE_BUILD_TYPE", "Release")
+                         .build();
+    dst.push("lib");
+    println!("cargo:rustc-link-search=native={}", dst.display());
+    println!("cargo:rustc-link-lib=static=civetweb");
 }

--- a/civet-sys/build.rs
+++ b/civet-sys/build.rs
@@ -5,6 +5,8 @@ use cmake::Config;
 fn main() {
     let mut dst = Config::new("civetweb")
                          .define("CMAKE_BUILD_TYPE", "Release")
+                         .define("BUILD_TESTING", "OFF")
+                         .define("CIVETWEB_ALLOW_WARNINGS", "ON")
                          .build();
     dst.push("lib");
     println!("cargo:rustc-link-search=native={}", dst.display());

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -316,6 +316,7 @@ mod test {
     }
 
     #[test]
+    #[cfg(target_os = "windows")]
     fn dupe_port() {
         let port = port();
         let s1 = Server::start(cfg(port), noop);

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -6,7 +6,8 @@ extern crate civet_sys as ffi;
 use std::collections::HashMap;
 use std::io::prelude::*;
 use std::io::{self, BufWriter};
-use std::net::{SocketAddr, Ipv4Addr, SocketAddrV4};
+use std::net::{SocketAddr, IpAddr, Ipv4Addr};
+use std::str::FromStr;
 
 use conduit::{Handler, Extensions, TypeMap, Method, Scheme, Host};
 
@@ -97,12 +98,9 @@ impl<'a> conduit::Request for CivetRequest<'a> {
     }
 
     fn remote_addr(&self) -> SocketAddr {
-        let ip = self.request_info.remote_ip();
-        let ip = Ipv4Addr::new((ip >> 24) as u8,
-                               (ip >> 16) as u8,
-                               (ip >>  8) as u8,
-                               (ip >>  0) as u8);
-        SocketAddr::V4(SocketAddrV4::new(ip, self.request_info.remote_port()))
+        let ip = self.request_info.remote_addr();
+        let ip = IpAddr::from_str(ip).unwrap_or_else(|_| Ipv4Addr::new(0, 0, 0, 0).into());
+        SocketAddr::new(ip, self.request_info.remote_port())
     }
 
     fn content_length(&self) -> Option<u64> {
@@ -360,9 +358,9 @@ mod test {
         let ip = Ipv4Addr::new(127, 0, 0, 1);
         let addr = SocketAddr::V4(SocketAddrV4::new(ip, port));
         let _s = Server::start(cfg(port), handler);
-        request(addr, r"
-GET / HTTP/1.1
-
+        request(addr, "\r
+GET / HTTP/1.1\r
+\r
 ");
         rx.recv().unwrap();
     }
@@ -385,10 +383,10 @@ GET / HTTP/1.1
         let ip = Ipv4Addr::new(127, 0, 0, 1);
         let addr = SocketAddr::V4(SocketAddrV4::new(ip, port));
         let _s = Server::start(cfg(port), handler);
-        request(addr, r"
-GET / HTTP/1.1
-Foo: bar
-
+        request(addr, "\r
+GET / HTTP/1.1\r
+Foo: bar\r
+\r
 ");
         assert_eq!(rx.recv().unwrap(), "bar");
     }
@@ -406,10 +404,10 @@ Foo: bar
         let ip = Ipv4Addr::new(127, 0, 0, 1);
         let addr = SocketAddr::V4(SocketAddrV4::new(ip, port));
         let _s = Server::start(cfg(port), Foo);
-        request(addr, r"
-GET / HTTP/1.1
-Foo: bar
-
+        request(addr, "\r
+GET / HTTP/1.1\r
+Foo: bar\r
+\r
 ");
     }
 
@@ -426,10 +424,10 @@ Foo: bar
         let ip = Ipv4Addr::new(127, 0, 0, 1);
         let addr = SocketAddr::V4(SocketAddrV4::new(ip, port));
         let _s = Server::start(cfg(port), Foo);
-        let response = request(addr, r"
-GET / HTTP/1.1
-Foo: bar
-
+        let response = request(addr, "\r
+GET / HTTP/1.1\r
+Foo: bar\r
+\r
 ");
         assert!(response.contains("500 Internal"),
                 "not a failing response: {}", response);


### PR DESCRIPTION
Fixes #8

This is the first step to get [rust-lang/crates.io](https://github.com/rust-lang/crates.io "crates.io git repository") running on Windows.

Because I don't have access to an Apple device, this PR wasn't tested on macOS. However, I've been able to test a Windows version of crates.io and I get 0-failures after updating to this version of civet.

Civetweb was updated to its latest released stable version (1.9.1), the build
script for civet-sys now uses the cmake crate making compatibilty with
Windows easy.

The cmake build script:

* forces the "Release" build type to disable debug logging in civetweb;
* disables building the tests, because they are not used;
* allow warnings at compile-time, can be pretty common on Linux;