### PR TITLE
Update civetweb to 1.10

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [project]
 
 name = "civet"
-version = "0.10.0"
+version = "0.11.0"
 authors = ["wycats"]
 license = "MIT"
 description = "civetweb-based server implementation for conduit"
@@ -14,7 +14,7 @@ libc = "0.2"
 
 [dependencies.civet-sys]
 path = "civet-sys"
-version = "0.2.0"
+version = "0.3.0"
 
 [dev-dependencies]
 route-recognizer = "0.1.0"

--- a/civet-sys/Cargo.toml
+++ b/civet-sys/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 
 name = "civet-sys"
-version = "0.2.0"
+version = "0.3.0"
 authors = ["Alex Crichton <alex@alexcrichton.com>"]
 links = "civet"
 build = "build.rs"

--- a/src/raw.rs
+++ b/src/raw.rs
@@ -134,7 +134,6 @@ pub struct MgRequestInfo {
     request_method: *const c_char,
     request_uri: *const c_char,
     local_uri: *const c_char,
-    uri: *const c_char,
     http_version: *const c_char,
     query_string: *const c_char,
     remote_user: *const c_char,
@@ -172,7 +171,7 @@ impl<'a> RequestInfo<'a> {
     }
 
     pub fn url(&self) -> Option<&str> {
-        to_slice(self.as_ref(), |info| info.uri)
+        to_slice(self.as_ref(), |info| info.local_uri)
     }
 
     pub fn http_version(&self) -> Option<&str> {
@@ -208,12 +207,12 @@ struct MgCallbacks {
     log_access: *const c_void,
     init_ssl: *const c_void,
     connection_close: *const c_void,
-    open_file: *const c_void,
     init_lua: *const c_void,
     http_error: *const c_void,
     init_context: *const c_void,
     init_thread: *const c_void,
-    exit_context: *const c_void
+    exit_context: *const c_void,
+    init_connection: *const c_void
 }
 
 impl MgCallbacks {
@@ -225,12 +224,12 @@ impl MgCallbacks {
             log_access: null(),
             init_ssl: null(),
             connection_close: null(),
-            open_file: null(),
             init_lua: null(),
             http_error: null(),
             init_context: null(),
             init_thread: null(),
-            exit_context: null()
+            exit_context: null(),
+            init_connection: null()
         }
     }
 }


### PR DESCRIPTION
I've updated the civetweb dependency to version 1.10 in order to fix the compile error on macOS introduced in version 1.9.

This release deprecated the `uri` field in the `MgRequest` structure but this didn't seem to affect either the tests nor the crates.io tests.

Fixes #12 